### PR TITLE
Fix double-replace

### DIFF
--- a/index.html
+++ b/index.html
@@ -1116,7 +1116,7 @@
                     //do nothing
                 }
                 else{
-                    var cleanKey = key.trim().replace(".", " ").replace("in:", "").replace("out:", "");
+                    var cleanKey = key.trim().replace("in:", "").replace("out:", "");
                     cleanedKeys4pc[cleanKey] = {};
                 }
 


### PR DESCRIPTION
Hello,

I got a JS error in `d3.parcoords.js` when I tried to load my CSV file into Design Explorer and traced it back to this. In one code path a key is "cleaned" by replacing just the first period with a space, while in another it happens twice. If one of your CSV columns contains two or more periods, this discrepancy will break the visualization.

Alternatively, you might want to change the "replace" on line 1109 to a "replace all" (`.replace(/\./g, ' ')`).

Thanks for the great tool!